### PR TITLE
Do not include certificate_id in Install RPC if a GenerateCSRRequest …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gnoic
 _test/
+*.pem

--- a/app/certInstall.go
+++ b/app/certInstall.go
@@ -198,7 +198,8 @@ func (a *App) CertInstall(ctx context.Context, t *Target) error {
 						Type:        cert.CertificateType(cert.CertificateType_value[a.Config.CertInstallCertificateType]),
 						Certificate: b,
 					},
-					CertificateId: a.Config.CertInstallCertificateID,
+					// do not include certificate_id if a GenerateCSRRequest was previously sent on the stream
+					// CertificateId: a.Config.CertInstallCertificateID,
 				},
 			},
 		})


### PR DESCRIPTION
…was previously sent on the stream