### PR TITLE
Add support for SystemSetPackage RPC

### DIFF
--- a/api/system/options.go
+++ b/api/system/options.go
@@ -750,3 +750,100 @@ func ProcessRestart(b bool) func(msg proto.Message) error {
 		return nil
 	}
 }
+
+func PackageFile(n string) func(msg proto.Message) error {
+	return func(msg proto.Message) error {
+		if msg == nil {
+			return fmt.Errorf("option PackageFile: %w", api.ErrInvalidMsgType)
+		}
+
+		switch msg := msg.ProtoReflect().Interface().(type) {
+		case *gnoisystem.SetPackageRequest:
+			switch m := msg.GetRequest().(type) {
+			case *gnoisystem.SetPackageRequest_Package:
+				m.Package.Filename = n
+			default:
+				return api.ErrInvalidMsgType
+			}
+		default:
+			return fmt.Errorf("option PackageFile: %w", api.ErrInvalidMsgType)
+		}
+
+		return nil
+	}
+}
+
+func Version(v string) func(msg proto.Message) error {
+	return func(msg proto.Message) error {
+		if msg == nil {
+			return fmt.Errorf("option Version: %w", api.ErrInvalidMsgType)
+		}
+
+		switch msg := msg.ProtoReflect().Interface().(type) {
+		case *gnoisystem.SetPackageRequest:
+			switch m := msg.GetRequest().(type) {
+			case *gnoisystem.SetPackageRequest_Package:
+				m.Package.Version = v
+			default:
+				return api.ErrInvalidMsgType
+			}
+		default:
+			return fmt.Errorf("option Version: %w", api.ErrInvalidMsgType)
+		}
+
+		return nil
+	}
+}
+
+func Activate(b bool) func(msg proto.Message) error {
+	return func(msg proto.Message) error {
+		if msg == nil {
+			return fmt.Errorf("option Activate: %w", api.ErrInvalidMsgType)
+		}
+
+		switch msg := msg.ProtoReflect().Interface().(type) {
+		case *gnoisystem.SetPackageRequest:
+			switch m := msg.GetRequest().(type) {
+			case *gnoisystem.SetPackageRequest_Package:
+				m.Package.Activate = b
+			default:
+				return api.ErrInvalidMsgType
+			}
+		default:
+			return fmt.Errorf("option Version: %w", api.ErrInvalidMsgType)
+		}
+
+		return nil
+	}
+}
+
+func Hash(method string, b []byte) func(msg proto.Message) error {
+	return func(msg proto.Message) error {
+		if msg == nil {
+			return fmt.Errorf("option Hash: %w", api.ErrInvalidMsgType)
+		}
+
+		ht, ok := types.HashType_HashMethod_value[strings.ToUpper(method)]
+		if !ok {
+			return api.ErrInvalidValue
+		}
+
+		switch msg := msg.ProtoReflect().Interface().(type) {
+		case *gnoisystem.SetPackageRequest:
+			switch m := msg.GetRequest().(type) {
+			case *gnoisystem.SetPackageRequest_Hash:
+				m.Hash = &types.HashType{
+					Method: types.HashType_HashMethod(ht),
+					Hash:   b,
+				}
+			default:
+				return fmt.Errorf("option Hash: %w", api.ErrInvalidMsgType)
+			}
+
+		default:
+			return fmt.Errorf("option Hash: %w", api.ErrInvalidMsgType)
+		}
+
+		return nil
+	}
+}

--- a/api/system/set_package.go
+++ b/api/system/set_package.go
@@ -1,0 +1,28 @@
+package system
+
+import gnoisystem "github.com/openconfig/gnoi/system"
+
+func NewSetPackagePackageRequest(opts ...SystemOption) (*gnoisystem.SetPackageRequest, error) {
+	m := &gnoisystem.SetPackageRequest{
+		Request: &gnoisystem.SetPackageRequest_Package{
+			Package: &gnoisystem.Package{},
+		},
+	}
+	err := apply(m, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func NewSetPackageHashRequest(opts ...SystemOption) (*gnoisystem.SetPackageRequest, error) {
+	m := &gnoisystem.SetPackageRequest{
+		Request: &gnoisystem.SetPackageRequest_Hash{},
+	}
+
+	err := apply(m, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/app/systemSetPackage.go
+++ b/app/systemSetPackage.go
@@ -2,27 +2,222 @@ package app
 
 import (
 	"context"
+	"crypto/sha512"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+
+	gsystem "github.com/karimra/gnoic/api/system"
+	"github.com/openconfig/gnoi/system"
+	gnoisystem "github.com/openconfig/gnoi/system"
 
 	"github.com/karimra/gnoic/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"google.golang.org/grpc/metadata"
 )
+
+type setPackageResponse struct {
+	TargetError
+}
 
 func (a *App) InitSystemSetPackageFlags(cmd *cobra.Command) {
 	cmd.ResetFlags()
 	//
+	cmd.Flags().StringVar(&a.Config.SystemSetPackageFile, "pkg", "", "file to put on the target(s)")
+	cmd.Flags().StringVar(&a.Config.SystemSetPackageDstFile, "dst", "", "path and filename on the target(s)")
+	cmd.Flags().StringVar(&a.Config.SystemSetPackageVersion, "version", "", "package version")
+	cmd.Flags().BoolVar(&a.Config.SystemSetPackageActivate, "activate", false, "make package active")
+	cmd.Flags().StringVar(&a.Config.SystemSetPackageRemoteFile, "remote", "", "path to the package for remote download")
+	cmd.Flags().Uint64Var(&a.Config.SystemSetPackageChunkSize, "content-chunk-size", defaultChunkSize, "max chunk size to transfer the package")
 	//
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		a.Config.FileConfig.BindPFlag(fmt.Sprintf("%s-%s", cmd.Name(), flag.Name), flag)
 	})
 }
 
-func (a *App) RunESystemSetPackage(cmd *cobra.Command, args []string) error {
-	fmt.Println("not implemented")
+func (a *App) PreRunESetPackage(cmd *cobra.Command, args []string) error {
+	a.Config.SetLocalFlagsFromFile(cmd)
+
+	if a.Config.SystemSetPackageFile == "" {
+		return errors.New("missing --pkg flag")
+	}
+
+	if a.Config.SystemSetPackageVersion == "" {
+		return errors.New("missing --version flag")
+	}
+
+	if a.Config.SystemSetPackageDstFile == "" {
+		return errors.New("missing --dst flag")
+	}
+
+	if a.Config.SystemSetPackageRemoteFile != "" {
+		return errors.New("remote is not implemented")
+	}
+
 	return nil
 }
 
+func (a *App) RunESystemSetPackage(cmd *cobra.Command, args []string) error {
+	targets, err := a.GetTargets()
+	if err != nil {
+		return err
+	}
+
+	numTargets := len(targets)
+	responseChan := make(chan *setPackageResponse, numTargets)
+
+	a.wg.Add(numTargets)
+
+	for _, t := range targets {
+		go func(t *api.Target) {
+			defer a.wg.Done()
+
+			ctx, cancel := context.WithCancel(a.ctx)
+			defer cancel()
+
+			ctx = metadata.AppendToOutgoingContext(ctx, "username", *t.Config.Username, "password", *t.Config.Password)
+
+			err = t.CreateGrpcClient(ctx, a.createBaseDialOpts()...)
+			if err != nil {
+				responseChan <- &setPackageResponse{
+					TargetError: TargetError{
+						TargetName: t.Config.Name,
+						Err:        err,
+					},
+				}
+				return
+			}
+
+			defer t.Close()
+
+			err = a.SystemSetPackage(ctx, t)
+			responseChan <- &setPackageResponse{
+				TargetError: TargetError{
+					TargetName: t.Config.Name,
+					Err:        err,
+				},
+			}
+		}(t)
+	}
+
+	a.wg.Wait()
+
+	close(responseChan)
+
+	errs := make([]error, 0, numTargets)
+
+	for rsp := range responseChan {
+		if rsp.Err != nil {
+			wErr := fmt.Errorf("%q SetPackage failed: %v", rsp.TargetName, rsp.Err)
+			a.Logger.Error(wErr)
+			errs = append(errs, wErr)
+			continue
+		}
+		a.Logger.Infof("%q package %s sent successfully", rsp.TargetName, a.Config.SystemSetPackageFile)
+	}
+
+	return a.handleErrs(errs)
+}
+
 func (a *App) SystemSetPackage(ctx context.Context, t *api.Target) error {
+	sysc := gnoisystem.NewSystemClient(t.Conn())
+	sysSetPackageClient, err := sysc.SetPackage(ctx)
+	if err != nil {
+		return err
+	}
+
+	a.Logger.Infof("target %q: starting SetPackage stream", t.Config.Name)
+
+	filename := a.Config.SystemSetPackageFile
+	_, err = os.Stat(filename)
+	if err != nil {
+		return fmt.Errorf("file %q stat err: %v", filename, err)
+	}
+
+	err = a.sendSysPackageFile(filename, a.Config.SystemSetPackageDstFile, sysSetPackageClient, t)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (a *App) sendSysPackageFile(fileName, remoteFile string, sysClient system.System_SetPackageClient, t *api.Target) error {
+	f, err := os.Open(fileName)
+	if err != nil {
+		a.Logger.Errorf("failed opening file %q: %v", fileName, err)
+
+		return err
+	}
+
+	defer f.Close()
+
+	a.Logger.Infof("%q sending file=%q", t.Config.Address, fileName)
+
+	req, err := gsystem.NewSetPackagePackageRequest(
+		gsystem.PackageFile(remoteFile),
+		gsystem.Version(a.Config.SystemSetPackageVersion),
+		gsystem.Activate(a.Config.SystemSetPackageActivate),
+	)
+	if err != nil {
+		return err
+	}
+
+	a.printMsg(t.Config.Name, req)
+	err = sysClient.Send(req)
+	if err != nil {
+		return err
+	}
+
+	h := sha512.New()
+
+	for {
+		b := make([]byte, a.Config.SystemSetPackageChunkSize)
+
+		n, err := f.Read(b)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if err == io.EOF || n == 0 {
+			break
+		}
+
+		h.Write(b[:n])
+
+		a.Logger.Debugf("%q file=%q, writing %d byte(s)", t.Config.Address, fileName, n)
+
+		reqContents := &gnoisystem.SetPackageRequest{
+			Request: &gnoisystem.SetPackageRequest_Contents{
+				Contents: b[:n],
+			},
+		}
+
+		err = sysClient.Send(reqContents)
+		if err != nil {
+			return err
+		}
+	}
+
+	// send hash
+	a.Logger.Infof("%q sending file=%q hash", t.Config.Address, fileName)
+
+	reqHash, err := gsystem.NewSetPackageHashRequest(
+		gsystem.Hash("SHA512", h.Sum(nil)),
+	)
+	if err != nil {
+		return err
+	}
+
+	a.printMsg(t.Config.Name, reqHash)
+
+	err = sysClient.Send(reqHash)
+	if err != nil {
+		return err
+	}
+
+	rsp, err := sysClient.CloseAndRecv()
+	a.printMsg(t.Config.Name, rsp)
+	return err
 }

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -78,6 +78,7 @@ func newSystemSetPackageCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			gApp.Config.SetLocalFlagsFromFile(cmd)
 		},
+		PreRunE:      gApp.PreRunESetPackage,
 		RunE:         gApp.RunESystemSetPackage,
 		SilenceUsage: true,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -198,6 +198,7 @@ type LocalFlags struct {
 	SystemSwitchControlProcessorPath string `json:"system-switch-control-processor-path,omitempty" mapstructure:"system-switch-control-processor-path,omitempty" yaml:"system-switch-control-processor-path,omitempty"`
 	// System SetPackage
 	SystemSetPackageFile        string `json:"system-set-package-file,omitempty" mapstructure:"system-set-package-file,omitempty" yaml:"system-set-package-file,omitempty"`
+	SystemSetPackageDstFile     string `json:"system-set-package-dst-file,omitempty" mapstructure:"system-set-package-dst-file,omitempty" yaml:"system-set-package-dst-file,omitempty"`
 	SystemSetPackageVersion     string `json:"system-set-package-version,omitempty" mapstructure:"system-set-package-version,omitempty" yaml:"system-set-package-version,omitempty"`
 	SystemSetPackageActivate    bool   `json:"system-set-package-activate,omitempty" mapstructure:"system-set-package-activate,omitempty" yaml:"system-set-package-activate,omitempty"`
 	SystemSetPackageRemoteFile  string `json:"system-set-package-remote-file,omitempty" mapstructure:"system-set-package-remote-file,omitempty" yaml:"system-set-package-remote-file,omitempty"`


### PR DESCRIPTION
Tested on Nokia SROS 22.7.R2. 
```
A:admin# list SROS
Volume in drive cf3 on slot A is TIMOS-CPMA.
Volume in drive cf3 on slot A is formatted as FAT32
Directory of cf3:

MINOR: MGMT_AGENT #2005: Invalid element value - open directory "SROS"
```

```
$ ./gnoic -a ipaddr -u $USER -p $PASS system set-package --pkg SROS/isa-aa.tim --version 23.3.R1 --dst cf3:/SROS/isa-aa.tim --insecure --content-chunk-size 1000 
WARN[0000] "ipaddr" could not lookup hostname: lookup .in-addr.arpa. on :53: no such host 
INFO[0000] target "ipaddr:57400": starting SetPackage stream 
INFO[0000] "ipaddr:57400" sending file="SROS/isa-aa.tim" 
INFO[0016] "ipaddr:57400" sending file="SROS/isa-aa.tim" hash 
INFO[0019] "ipaddr:57400" package SROS/isa-aa.tim sent successfully
```
```
[/file "cf3:\"]
A:admin# list SROS
Volume in drive cf3 on slot A is TIMOS-CPMA.
Volume in drive cf3 on slot A is formatted as FAT32
Directory of cf3:\SROS
06/19/2023  05:59a      <DIR>          ./
06/19/2023  05:59a      <DIR>          ../
06/19/2023  05:59a            30094752 isa-aa.tim
               1 File(s)               30094752 bytes.
               2 Dir(s)              9768796160 bytes free.
```

```
$ ./gnoic -a ipaddr -u $USER -p $PASS system set-package --pkg SROS/isa-aa.tim --version 23.3.R2 --dst cf3:/SROS/isa-aa.tim --insecure 
WARN[0000] "ipaddr" could not lookup hostname: lookup .in-addr.arpa. on :53: no such host 
INFO[0000] target "ipaddr:57400": starting SetPackage stream 
INFO[0000] "ipaddr:57400" sending file="SROS/isa-aa.tim" 
INFO[0014] "ipaddr:57400" sending file="SROS/isa-aa.tim" hash 
ERRO[0017] "ipaddr:57400" SetPackage failed: rpc error: code = InvalidArgument desc = MINOR: GMI #2009: Invalid ProtoBuf leaf value - image version mismatch - 23.3.R1 expected 23.3.R2 
Error: there was 1 error(s)
```
@karimra  please review