### PR TITLE
osInstall: add package_size into TransferRequest

### DIFF
--- a/api/os/options.go
+++ b/api/os/options.go
@@ -77,6 +77,21 @@ func StandbySupervisor(b bool) func(msg proto.Message) error {
 	}
 }
 
+func PackageSize(pkgSize uint64) func(msg proto.Message) error {
+	return func(msg proto.Message) error {
+		if msg == nil {
+			return fmt.Errorf("option PackageSize: %w", api.ErrInvalidMsgType)
+		}
+		switch msg := msg.ProtoReflect().Interface().(type) {
+		case *gnoios.TransferRequest:
+			msg.PackageSize = pkgSize
+		default:
+			return fmt.Errorf("option PackageSize: %w", api.ErrInvalidMsgType)
+		}
+		return nil
+	}
+}
+
 func NoReboot(b bool) func(msg proto.Message) error {
 	return func(msg proto.Message) error {
 		if msg == nil {

--- a/app/osInstall.go
+++ b/app/osInstall.go
@@ -102,9 +102,15 @@ func (a *App) OsInstall(ctx context.Context, t *api.Target) error {
 		return err
 	}
 	a.Logger.Infof("target %q: starting Install stream", t.Config.Name)
+
+	pkgInfo, err := os.Stat(a.Config.OsInstallPackage)
+	if err != nil {
+		return err
+	}
 	req, err := gos.NewOSInstallTransferRequest(
 		gos.Version(a.Config.OsInstallVersion),
 		gos.StandbySupervisor(a.Config.OsInstallStandbySupervisor),
+		gos.PackageSize(uint64(pkgInfo.Size())),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This will let the server know how large the
incoming image is, so it can free up space accordingly.